### PR TITLE
feat: add ignore address type for token transfer monitoring

### DIFF
--- a/src/AElfScanServer.Worker.Core/Dtos/TransferEventDto.cs
+++ b/src/AElfScanServer.Worker.Core/Dtos/TransferEventDto.cs
@@ -31,7 +31,8 @@ public enum AddressClassification
     Normal,
     Blacklist,
     ToOnlyMonitored,
-    LargeAmountOnly
+    LargeAmountOnly,
+    Ignore
 }
 
 /// <summary>

--- a/src/AElfScanServer.Worker.Core/Options/TokenTransferMonitoringOptions.cs
+++ b/src/AElfScanServer.Worker.Core/Options/TokenTransferMonitoringOptions.cs
@@ -30,6 +30,11 @@ public class TokenTransferMonitoringOptions
     public List<string> LargeAmountOnlyAddresses { get; set; } = new();
 
     /// <summary>
+    /// Addresses to ignore completely - no metrics will be recorded for these addresses
+    /// </summary>
+    public List<string> IgnoreAddresses { get; set; } = new();
+
+    /// <summary>
     /// Minimum USD value threshold for histogram recording, default is 0
     /// </summary>
     public decimal MinUsdValueThreshold { get; set; } = 0m;

--- a/src/AElfScanServer.Worker/appsettings.json
+++ b/src/AElfScanServer.Worker/appsettings.json
@@ -264,12 +264,55 @@
   },
   "TokenTransferMonitoring": {
     "EnableMonitoring": true,
-    "EnableSystemContractFilter":false,
+    "EnableSystemContractFilter":true,
     "BlacklistAddresses": [
-      "2Ue8S2qAb8dGMrRgcNtjWgBx48Bx3XmNT6UBBKwNLYm5ZpbA"],
+      "2Ue8S2qAb8dGMrRgcNtjWgBx48Bx3XmNT6UBBKwNLYm5ZpbA",
+      "kh8TeQiTzr3FWAmNN3fd97fjsNtPVeNr9cxtkdkFf2gyuxXDn",
+      "B6dvH6p93zMD3rE3zESRVt3gRQg2e8rHw34h1ZJNXxoWNBYjB",
+      "k9qVGtY5usEhViiacGvXGgNb8wpCEEwFU14w4rxoXAxgZwREF",
+      "q6w7NcsfLeGSMnNTmXKMnaRUPKSk7yczS4YCd6ZJC4XNTDcb8",
+      "hUkyUrCNoSuTuduYTbSKCCoHn17fvtX8NYVRNgnhFhpxAyoTt",
+      "2vJMKR3DqeLffJcjCEquvaR1hTQ2MS7mfpcK3bD8QEiRorDVdG"
+    ],
+    "ToOnlyMonitoredAddresses": [
+      "2cbyVVSin9aHZzwdjHHGP3HLZxHgo7dKB5S7HdNGaXkwkpvHfT",
+      "2vGq6qQi9qJSdn5yjhQ7tpez16qQnEKuRCZHoQiUkGBMC34MdT",
+      "2PPYHTa582wijxchyrniTTWG1SG2QHhV8eLutP4MXRrnUc52uw",
+      "2imJ6W4ada5wNq735WVEisDfkVgGWDbSxHSyhmwXBBsgKWmMSr",
+      "2LB3MevN2QSW36ahkFJ6PxEPWFwunpCPQYAWCEXFaNzVwMDrdr",
+      "nxREyjyKXqzA7aQaK4Nc7EVNL2BWaiFSrDturUQfWwJ4uwW6b",
+      "eGw4LRJpXWZKcRRuxUi1uhqjJafEpzow4ZzQgnPmRJv7ReGrK",
+      "2RWf7Aj7Cn2UpZcXVrXLL7iWfhdHz69otYY1YDJ4X158cVNWG2",
+      "2VeAzekM7bEMisNMyJpRCAARgPcnuFoJVw9uXfWnGa8RX2tnuZ",
+      "KPFwtmxK48mDjKYTWeYFDfkSmnPNPFrEXAxyJf84jX5ytaGg8",
+      "29tJaX3k16ZibaXYz2yq9ZbeN4G7cLWJyAucGcSoCsLwhnkAoy",
+      "2eZtVJvL26DqmKgzQzULK764ihMCoXKTqgK7NzbPBCRRmuBZgz",
+      "bUxH4xMXHi2yisGd1GCjb81oWVavfXbEeXZ96vNdv4hpBhdeM",
+      "2PxkDj9tzyNBnAvuGhLVgUPr8bPN4r1DALYVPhYcsjQficvrUV",
+      "2cvQi5yLSvyni6xdUHXRynesz2nDQCDMBAyFG2QqA6iVSBDvtH",
+      "5CazTqiizhhDgn9QmPFqHEmJ7EspCRqVoencfCe3r7Qkog3c3",
+      "2NCCXHS48wyGyjxczJ19qUA4nmPz1HxfUAi359XWvTo4tzdNzM",
+      "g6LeMdzLcUPccrK97TWYSxri1NxK6ZXJwQjv1VUNf1F8BzfF3",
+      "2sVo6v1ysTefrFT1bStsoztnCGQHkZEjFK9mSUWjEP6nGnoma1",
+      "AERrwTnr9LE8Tu682FP1jpUSeJhwAuB8cSgR86SgMGqmeS6ii",
+      "zaVUYRhCkrurJfMs2EfTUnruJ9qeAbJ4jmsVM7wcaAPcDuKnt",
+      "FiXvL7pdz9uFYajitRVQw64EVNcu6vXqss3phMkVLTcCCFQ7d"
+    ],
+    "LargeAmountOnlyAddresses": [
+      "2b7Gf7YqVmjhZXir7uehmZoRwsYo1KNFTo9JDZiiByxPBQS1d8",
+      "2AJXAXSwyHbKTHQhKFiaYozakUUQDeh3xrHW9FGi3vYDMBjtiS",
+      "25CkLPA8qwDRGQci2kFg77i6pZXVivvX4DHW78i1B7rPHdBkoK",
+      "2PwfVguYDmYcpJVPmoH9doEpBgd8L28NCcUDiuq77CzvEWzuKZ",
+      "2eJ4MnRWFo7YJXB92qj2AF3NWoB3umBggzNLhbGeahkwDYYLAD"
+    ],
+    "IgnoreAddresses": [
+      "ExampleIgnoreAddress1234567890ABCDEFGHIJKLMNOPQRST",
+      "TestIgnoreAddress2345678901BCDEFGHIJKLMNOPQRSTUV"
+    ],
+    "MinUsdValueThreshold": 0.1,
     "MonitoredTokens": ["ELF", "USDT", "BTC", "ETH"],
     "ScanConfig": {
-      "ChainIds": ["AELF", "tDVW"],
+      "ChainIds": ["AELF", "tDVV"],
       "IntervalSeconds": 30,
       "BatchSize": 1000
     }


### PR DESCRIPTION
- Add Ignore type to AddressClassification enum
- Add IgnoreAddresses configuration option
- Update monitoring service to skip metrics for ignore addresses individually
- Only skip the specific address metrics, not the entire transaction
- Add detailed logging for ignored addresses