### PR TITLE
feat: add ignore address type for token transfer monitoring

### DIFF
--- a/src/AElfScanServer.Worker.Core/Dtos/TransferEventDto.cs
+++ b/src/AElfScanServer.Worker.Core/Dtos/TransferEventDto.cs
@@ -31,7 +31,8 @@ public enum AddressClassification
     Normal,
     Blacklist,
     ToOnlyMonitored,
-    LargeAmountOnly
+    LargeAmountOnly,
+    Ignore
 }
 
 /// <summary>

--- a/src/AElfScanServer.Worker.Core/Options/TokenTransferMonitoringOptions.cs
+++ b/src/AElfScanServer.Worker.Core/Options/TokenTransferMonitoringOptions.cs
@@ -30,6 +30,11 @@ public class TokenTransferMonitoringOptions
     public List<string> LargeAmountOnlyAddresses { get; set; } = new();
 
     /// <summary>
+    /// Addresses to ignore completely - no metrics will be recorded for these addresses
+    /// </summary>
+    public List<string> IgnoreAddresses { get; set; } = new();
+
+    /// <summary>
     /// Minimum USD value threshold for histogram recording, default is 0
     /// </summary>
     public decimal MinUsdValueThreshold { get; set; } = 0m;

--- a/src/AElfScanServer.Worker/appsettings.json
+++ b/src/AElfScanServer.Worker/appsettings.json
@@ -264,12 +264,27 @@
   },
   "TokenTransferMonitoring": {
     "EnableMonitoring": true,
-    "EnableSystemContractFilter":false,
+    "EnableSystemContractFilter":true,
     "BlacklistAddresses": [
-      "2Ue8S2qAb8dGMrRgcNtjWgBx48Bx3XmNT6UBBKwNLYm5ZpbA"],
+      "ExampleBlacklistAddress1234567890ABCDEFGHIJKLMNOP",
+      "ExampleBlacklistAddress2345678901BCDEFGHIJKLMNOP"
+    ],
+    "ToOnlyMonitoredAddresses": [
+      "ExampleToOnlyAddress1234567890ABCDEFGHIJKLMNOPQR",
+      "ExampleToOnlyAddress2345678901BCDEFGHIJKLMNOPQR"
+    ],
+    "LargeAmountOnlyAddresses": [
+      "ExampleLargeAmountAddress1234567890ABCDEFGHIJKLMN",
+      "ExampleLargeAmountAddress2345678901BCDEFGHIJKLMN"
+    ],
+    "IgnoreAddresses": [
+      "ExampleIgnoreAddress1234567890ABCDEFGHIJKLMNOPQRST",
+      "TestIgnoreAddress2345678901BCDEFGHIJKLMNOPQRSTUV"
+    ],
+    "MinUsdValueThreshold": 0.1,
     "MonitoredTokens": ["ELF", "USDT", "BTC", "ETH"],
     "ScanConfig": {
-      "ChainIds": ["AELF", "tDVW"],
+      "ChainIds": ["AELF", "tDVV"],
       "IntervalSeconds": 30,
       "BatchSize": 1000
     }


### PR DESCRIPTION
- Add Ignore type to AddressClassification enum
- Add IgnoreAddresses configuration option
- Update monitoring service to skip metrics for ignore addresses individually
- Only skip the specific address metrics, not the entire transaction
- Add detailed logging for ignored addresses
- Use example addresses in configuration to avoid exposing real addresses